### PR TITLE
Downgrade nuget packages

### DIFF
--- a/sdk/PowerBI.Api.Tests/PowerBI.Api.Tests.csproj
+++ b/sdk/PowerBI.Api.Tests/PowerBI.Api.Tests.csproj
@@ -5,8 +5,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="3.0.3" />
-   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20171031-01" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
+   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
     <PackageReference Include="NewtonSoft.Json" Version="10.0.3" />

--- a/sdk/PowerBI.Api/PowerBI.Api.csproj
+++ b/sdk/PowerBI.Api/PowerBI.Api.csproj
@@ -12,7 +12,7 @@
         <tags>Microsoft Power BI API REST</tags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.10" />
     <PackageReference Include="NewtonSoft.Json" Version="10.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Thanks for the work porting this to standard unfortunately the bump to pre-release nuget packages is causing us issues.

This PR is intended to:
downgrade Microsoft.Rest.ClientRuntime to stable

This enables us to use
Microsoft.Azure.Search

## Description
Microsoft.Azure.Search and most of the other SDK's use version 2. and have a condition that requires them to be below v3

Microsoft.Azure.Search -> Microsoft.Rest.ClientRuntime (>= 2.3.7 && < 3.0.0).